### PR TITLE
Bugfix: Unnecessary whitespace in Goals list

### DIFF
--- a/immersionbotcogs/goals_manager.py
+++ b/immersionbotcogs/goals_manager.py
@@ -94,23 +94,14 @@ class Goals_manager(commands.Cog):
         if not goals:
             return await interaction.response.send_message(ephemeral=True, content='No goals found. Set goals with ``/set_goal``.')
 
-        goals_description = []
         codes_path = _IMMERSION_CODES
         try:
             with open(codes_path, "r") as file:
                 codes = json.load(file)
         except FileNotFoundError:
             codes = {}
-        for goal_row in goals:
-            try:
-                updated_date = f'<t:{int(datetime.strptime(goal_row.end, "%Y-%m-%d %H:%M:%S.%f%z").timestamp())}:R>'
-            except Exception:
-                updated_date = goal_row.end
-            goal_title = helpers.get_name_of_immersion(goal_row.media_type.value, goal_row.text, codes, codes_path)
-            if goal_row.current_amount < goal_row.amount:
-                    goals_description.append(f"""- {goal_row.current_amount}/{goal_row.amount} {helpers.media_type_format(goal_row.media_type.value) if goal_row.goal_type != "POINTS" else "points"} of [{goal_title[1]}]({goal_title[2]}) ({updated_date})""")
-            else:
-                goals_description.append(f"""~~- {goal_row.current_amount}/{goal_row.amount} {helpers.media_type_format(goal_row.media_type.value) if goal_row.goal_type != "POINTS" else "points"} of [{goal_title[1]}]({goal_title[2]}) ({updated_date})~~""")
+        
+        goals_description = helpers.get_goal_description(goals, codes_path, codes)
 
         results = []
         for i, goal in enumerate(zip(goals_description, goals)):

--- a/modals/constants.py
+++ b/modals/constants.py
@@ -27,6 +27,12 @@ ACHIEVEMENT_RANKS = ['Beginner', 'Initiate', 'Apprentice', 'Hobbyist', 'Enthusia
 ACHIEVEMENT_EMOJIS = [':new_moon:', ':new_moon_with_face:', ':waning_crescent_moon:', ':last_quarter_moon:', ':waning_gibbous_moon:', ':full_moon:', ':full_moon_with_face:', ':sun_with_face:']
 ACHIEVEMENT_IDS = [1120790734476423270, 1120790825702527037, 1120790890038952066, 1120790964970213436, 1120791040463470702, 1120791104518901912, 1120791193366823112, 1120791256818266112]
 
+GOAL_STATUS = {
+    "NO_PROGRESS": "<:gannbare:1097669283615604836>",
+    "PROGRESS": "<:naruhodo:1097669129672073296>",
+    "DONE": "<:NanaYay:837211306293067797>"
+}
+
 EMOJI_TABLE = {
     # 'Yay': 658999234787278848,
     # 'NanaYes': 837211260155854849,

--- a/modals/helpers.py
+++ b/modals/helpers.py
@@ -11,7 +11,7 @@ import tmdbsimple as tmdb
 import random
 import tmdbv3api
 import requests
-from modals.constants import ACHIEVEMENTS, PT_ACHIEVEMENTS, ACHIEVEMENT_RANKS, ACHIEVEMENT_EMOJIS, ACHIEVEMENT_IDS, EMOJI_TABLE, JACK_FILTER, TMDB_API_KEY
+from modals.constants import ACHIEVEMENTS, PT_ACHIEVEMENTS, ACHIEVEMENT_RANKS, ACHIEVEMENT_EMOJIS, ACHIEVEMENT_IDS, GOAL_STATUS, EMOJI_TABLE, JACK_FILTER, TMDB_API_KEY
 import asyncio
 from modals.goal import Goal
 from modals.constants import MESSAGE_FORMATS
@@ -232,10 +232,13 @@ def get_goal_description(goals, codes_path, codes):
         except Exception:
             updated_date = goal_row.end
         goal_title = get_name_of_immersion(goal_row.media_type.value, goal_row.text, codes, codes_path)
-        if goal_row.current_amount < goal_row.amount:
-                goals_description.append(f"""- {round(goal_row.current_amount, 2)}/{goal_row.amount} {media_type_format(goal_row.media_type.value) if goal_row.goal_type != "POINTS" else "points"} of [{goal_title[1]}]({goal_title[2]}) ({updated_date})""")
+        goal_details = f"""{round(goal_row.current_amount, 2)}/{goal_row.amount} {media_type_format(goal_row.media_type.value) if goal_row.goal_type != "POINTS" else "points"} of [{goal_title[1]}]({goal_title[2]}) ({updated_date})"""
+        if goal_row.current_amount == 0:
+            goals_description.append(f"{GOAL_STATUS['NO_PROGRESS']} {goal_details}")
+        elif goal_row.current_amount < goal_row.amount:
+            goals_description.append(f"{GOAL_STATUS['PROGRESS']} {goal_details}")
         else:
-            goals_description.append(f"""~~- {round(goal_row.current_amount, 2)}/{goal_row.amount} {media_type_format(goal_row.media_type.value) if goal_row.goal_type != "POINTS" else "points"} of [{goal_title[1]}]({goal_title[2]}) ({updated_date})~~""")
+            goals_description.append(f"{GOAL_STATUS['DONE']} ~~{goal_details}~~")
 
     return goals_description
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,9 +13,11 @@ exceptiongroup==1.2.2
 frozenlist==1.5.0
 idna==3.10
 iniconfig==2.0.0
+matplotlib==3.9.4
 multidict==6.1.0
 numpy==2.0.2
 packaging==24.1
+pandas==2.2.3
 pluggy==1.5.0
 propcache==0.2.0
 pytest==8.3.3

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -514,8 +514,26 @@ class TestLogCommand:
         assert self.interaction.edit_original_response.call_count == 1
         embed = self.interaction.edit_original_response.call_args[1]['embed']
         goal_field = next(field for field in embed.fields if field.name == 'Goals')
-        assert goal_field.value.startswith(f'- 0/10 mins of [LISTENING](https://anilist.co/home)')
+        assert ('0/10 mins of [LISTENING](https://anilist.co/home)' in goal_field.value)
+
+    @pytest.mark.asyncio
+    async def test_log_with_multiple_goal_display(self, setup):
+        #Tests if multiple goals are displayed correctly (without extra empty lines)
+        #on the log for a goal
+        #note: will pass even though Discord renders the embed with an empty line
+        cog, store = await setup
+        media_type = "ANIME"
         
+        # Execute the log command multiple times
+        await self.goal_media.set_goal_media.callback(self.goal_media, self.interaction, media_type='LISTENING', amount='10', name=None, span='DAY')
+        await self.goal_media.set_goal_media.callback(self.goal_media, self.interaction, media_type='ANIME', amount='2', name=None, span='DAY')
+        await cog.log.callback(cog, self.interaction, media_type='ANIME', amount='1', name=None, comment=None)
+        
+        assert self.interaction.edit_original_response.call_count == 1
+        embed = self.interaction.edit_original_response.call_args[1]['embed']
+        goal_field = next(field for field in embed.fields if field.name == 'Goals')
+        assert len(goal_field.value.split('\n')) == 2
+
     @pytest.mark.asyncio
     async def test_log_with_updating_goal_display(self, setup):
         #Tests if the goal is displayed correctly on the log for an related goal
@@ -529,4 +547,4 @@ class TestLogCommand:
         assert self.interaction.edit_original_response.call_count == 1
         embed = self.interaction.edit_original_response.call_args[1]['embed']
         goal_field = next(field for field in embed.fields if field.name == 'Goals')
-        assert goal_field.value.startswith(f'- 1/10 eps of [ANIME](https://anilist.co/home)')
+        assert ('1/10 eps of [ANIME](https://anilist.co/home)' in goal_field.value)


### PR DESCRIPTION
Fixes #21.

- Added some imports to `requirements.txt` because the setup guide wasn't working out of the box when using a virtual environment.
- Replaced list markers with emojis to avoid the extra newlines.

Before:
<img src="https://github.com/user-attachments/assets/84b2f43a-11d3-4275-b262-4c28fbf6ccc9" width="350">

After:
<img src="https://github.com/user-attachments/assets/213cb1c9-7e71-4efd-866f-46b348275e66" width="350">

I haven't found any mention of someone else experiencing this particular problem, but my guess is that this issue is caused by either the Python `discord` library or Discord itself. I double-checked that the embed is sent to Discord without the extra newline, and that the response comes back without the extra newline. This issue only occurs with Markdown list notation (`-`/`*`/`1.`), not regular newlines.

One workaround would be to use separate embed fields for individual goals, but that wouldn't really solve the problem as the empty field titles would still show up as extra space.

The other places in the code that use lists in embeds, like achievements progress, use emoji as list markers, so I took the same approach. Different emojis are used based on whether the goal has zero progress, some progress, or is completed.

Happy to replace the emojis if you think these aren't a good fit. Alternatively, we could use an unobtrusive list marker that wouldn't be picked up by markdown formatting like ":small_blue_diamond:".