### PR TITLE
Add matplotlib and pandas to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,5 @@ typing_extensions==4.12.2
 urllib3==2.2.3
 vndb-thigh-highs==0.1.8
 yarl==1.16.0
+matplotlib=3.10.7
+pandas=2.3.3


### PR DESCRIPTION
not sure if it's just me, but when i ran it i also needed matplot and pandas installed.  
For the library versions i just used the ones that i installed, so that would be the newest version; both worked fine for me.